### PR TITLE
aruha-1114 decouple application id from stack name

### DIFF
--- a/instance_control/aws/taupage.py
+++ b/instance_control/aws/taupage.py
@@ -36,7 +36,7 @@ def generate_user_data(cluster_config: dict) -> str:
     environment = cluster_config['environment']
     data = {'runtime': 'Docker',
             'source': cluster_config['docker_image'],
-            'application_id': cluster_config['cluster_name'],
+            'application_id': cluster_config['application_id'],
             'application_version': cluster_config['image_version'],
             'networking': 'host',
             'ports': {'9092': '9092',

--- a/instance_control/bubuku-1.json
+++ b/instance_control/bubuku-1.json
@@ -1,5 +1,6 @@
 {
   "cluster_name": "bubuku-1",
+  "application_id": "bubuku-appliance",
   "account": "aruha-test",
   "region": "eu-central-1",
   "vpc_id": "vpc-12345678",


### PR DESCRIPTION


[ARUHA-1114: SCM_URL_NOT_MATCH_WITH_KIO for bubuku](https://techjira.zalando.net/browse/ARUHA-1114)

## Description

When deploying a new bubuku stack, we don't want to necessarily have to
setup a new application in Kio. So we are decoupling application id from
stack name.

## Deployment Notes
Don't forget to always update all repositories, since this PR depends on configurations changed in the private repo.