### PR TITLE
aruha-1150: changed to flag

### DIFF
--- a/instance_control/bubuku_cluster.py
+++ b/instance_control/bubuku_cluster.py
@@ -25,7 +25,7 @@ def cli():
 @click.option('--ip', required=True)
 @click.option('--user', required=True)
 @click.option('--odd', required=True)
-@click.option('--force', type=bool, default=False)
+@click.option('--force', is_flag=True, default=False)
 def upgrade(image_version: str, cluster_config: str, ip: str, user: str, odd: str, force: bool):
     UpgradeCommand(cluster_config, image_version, ip, user, odd, force).run()
 


### PR DESCRIPTION
[ARUHA-1150: Force option for bubuku upgrade script](https://techjira.zalando.net/browse/ARUHA-1150)