### PR TITLE
aruha-1456 avoid region inconsistency

### DIFF
--- a/instance_control/command/terminate.py
+++ b/instance_control/command/terminate.py
@@ -18,5 +18,5 @@ class TerminateCommand(Command):
     def execute(self):
         aws_ = AWSResources(region=self.cluster_config['region'])
         instance = node.get_instance_by_ip(aws_.ec2_resource, self.cluster_config['cluster_name'], self.ip)
-        piu.stop_taupage(self.ip, self.user, self.odd)
+        piu.stop_taupage(self.ip, self.user, self.odd, self.cluster_config['region'])
         node.terminate(aws_, self.cluster_config['cluster_name'], instance)

--- a/instance_control/command/upgrade.py
+++ b/instance_control/command/upgrade.py
@@ -39,7 +39,7 @@ class UpgradeCommand(Command):
         data_volume = next(v for v in volumes['BlockDeviceMappings'] if v['DeviceName'] == '/dev/xvdk')
         data_volume_id = data_volume['Ebs']['VolumeId']
 
-        piu.stop_taupage(self.ip, self.user, self.odd)
+        piu.stop_taupage(self.ip, self.user, self.odd, self.cluster_config['region'])
 
         _LOG.info('Creating tag:Name=%s for %s', config.KAFKA_LOGS_EBS, data_volume_id)
         vol = aws_.ec2_resource.Volume(data_volume_id)

--- a/instance_control/piu.py
+++ b/instance_control/piu.py
@@ -5,9 +5,9 @@ import subprocess
 _LOG = logging.getLogger('bubuku.cluster.piu')
 
 
-def stop_taupage(ip: str, user: str, odd: str):
+def stop_taupage(ip: str, user: str, odd: str, region: str):
     _LOG.info('Stopping taupage container on %s', ip)
-    piu = ["piu", ip, "-O", odd, "\"detaching ebs, terminate and launch instance\""]
+    piu = ["piu", ip, "--region", region, "-O", odd, "\"detaching ebs, terminate and launch instance\""]
     _call(piu)
 
     stop = ["ssh", "-tA", user + '@' + odd, "ssh", "-o", "StrictHostKeyChecking=no", user + '@' + ip,


### PR DESCRIPTION
If the user executing the script has a default region different from the
one specified by the cluster config, the script is aborted.

This PR makes sure that the region used in piu is the same as the one
configured in the cluster parameters.

