### PR TITLE
Set some options to required for rolling-restart

### DIFF
--- a/bubuku/cli.py
+++ b/bubuku/cli.py
@@ -140,12 +140,12 @@ def restart_broker(broker: str):
 
 
 @cli.command('rolling-restart', help='Rolling restart of Kafka cluster')
-@click.option('--image-tag', type=click.STRING, help='Docker image to run Kafka broker')
+@click.option('--image-tag', type=click.STRING, required=True, help='Docker image to run Kafka broker')
 @click.option('--instance-type', type=click.STRING, default='m4.4xlarge',
               help='AWS instance type to run Kafka broker on')
-@click.option('--scalyr-key', type=click.STRING, help='Scalyr account key')
-@click.option('--scalyr-region', type=click.STRING, help='Scalyr region to use')
-@click.option('--kms-key-id', type=click.STRING, help='Kms key id to decrypt data with')
+@click.option('--scalyr-key', type=click.STRING, required=True, help='Scalyr account key')
+@click.option('--scalyr-region', type=click.STRING, required=True, help='Scalyr region to use')
+@click.option('--kms-key-id', type=click.STRING, required=True, help='Kms key id to decrypt data with')
 @click.option('--cool-down', type=click.INT, default=20, show_default=True,
               help='Number of seconds to wait before passing the restart task to another broker, after cluster is '
                    'stable')


### PR DESCRIPTION
[ARUHA-2434: Scalyr Logs for Bubuku](https://jira.zalando.net/browse/ARUHA-2434)

## Description
Make the options for rolling-restart required. (`image-tag`, `scalyr-key`, `scalyr-region` and `kms-key-id`)

For instance_control scripts, these arguments were already picked up from the config files, but for the `rolling-restart` operation, I think it is best to set them as `required`.