### PR TITLE
added additional filter of vpc id to migrate

### DIFF
--- a/instance_control/aws/security_group.py
+++ b/instance_control/aws/security_group.py
@@ -8,7 +8,7 @@ _LOG = logging.getLogger('bubuku.cluster.aws.security_group')
 def create_or_get_security_group(aws_: AWSResources, cluster_config: dict) -> dict:
     _LOG.info('Configuring security group ...')
     security_groups = aws_.ec2_client.describe_security_groups(
-        Filters=[{'Name': 'group-name', 'Values': [cluster_config['cluster_name']]}])
+        Filters=[{'Name': 'group-name', 'Values': [cluster_config['cluster_name']] }, {'Name': 'vpc-id', 'Values': [cluster_config['vpc_id']]}])
     if security_groups['SecurityGroups']:
         sg = security_groups['SecurityGroups'][0]
         _LOG.info('Security group for %s exists, will use it %s', cluster_config['cluster_name'], sg['GroupId'])


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-2397

## Description
In order to migrate bubuku we need to create a new security group in the new VPC. Since the old code fetched the old security group it had problems when launching a new bubuku instance. This is fixed in the PR. 

It is running on staging.
