### PR TITLE
Make sure new cluster's max compaction lag is 14 days

### DIFF
--- a/docker/server.properties
+++ b/docker/server.properties
@@ -35,6 +35,7 @@ log.flush.scheduler.interval.ms=2000
 log.roll.hours=168
 log.retention.check.interval.ms=300000
 log.segment.bytes=1073741824
+log.cleaner.max.compaction.lag.ms=1209600000
 
 # ZK configuration
 zookeeper.connection.timeout.ms=6000


### PR DESCRIPTION
As part of the global project for customer data deletion, log
compaction has a new maximum lag of 14 days, after which compaction
happens.

This change has already been applied dynamically to our production and
test cluster, but in the case a new cluster gets deployed in the
future, in order to avoid a "regression" from sneaking in, we better
build bubuku with this property by default, that way our current
solution becomes future proof.
