### PR TITLE
Fix CDP error with pyenv version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,12 @@ ENV SRC_PATH="/bubuku"
 ADD ./bubuku "${SRC_PATH}/bubuku"
 ADD ./requirements.txt "${SRC_PATH}/"
 ADD ./setup.py "${SRC_PATH}/"
-RUN cd "${SRC_PATH}" && pip3 install --no-cache-dir -r "requirements.txt" && python3 setup.py develop
+
+RUN cd "${SRC_PATH}" && \
+    apt-get update && \
+    apt-get install -y python3-pip && \
+    pip3 install --no-cache-dir -r "requirements.txt" && \
+    python3 setup.py develop
 
 EXPOSE 9092 8080 8778
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,7 @@ ENV SRC_PATH="/bubuku"
 ADD ./bubuku "${SRC_PATH}/bubuku"
 ADD ./requirements.txt "${SRC_PATH}/"
 ADD ./setup.py "${SRC_PATH}/"
-
-RUN cd "${SRC_PATH}" && \
-    apt-get update && \
-    apt-get install -y python3-pip && \
-    pip3 install --no-cache-dir -r "requirements.txt" && \
-    python3 setup.py develop
+RUN cd "${SRC_PATH}" && pip3 install --no-cache-dir -r "requirements.txt" && python3 setup.py develop
 
 EXPOSE 9092 8080 8778
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,8 +3,6 @@ pipeline:
   - id: build
     type: script
     overlay: guild-python/legacy
-    env:
-        PYENV_VERSION: 3.6.9
     commands:
       - desc: Install Docker
         cmd: |

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -25,7 +25,7 @@ pipeline:
           if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
             docker push $IMAGE
           fi
-          TEST_IMAGE="registry-write.opensource.zalan.do/aruha/bubuku:test-${CDP_BUILD_VERSION}"
+          TEST_IMAGE="registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-test-${CDP_BUILD_VERSION}"
           docker tag "$IMAGE" "$TEST_IMAGE"
           docker push "$TEST_IMAGE"
 notifications:

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,6 +3,8 @@ pipeline:
   - id: build
     type: script
     overlay: guild-python/legacy
+    env:
+        PYENV_VERSION: 3.6.10
     commands:
       - desc: Install Docker
         cmd: |


### PR DESCRIPTION
CDP is logging

```
+ pip3 install -r requirements.txt
pyenv: version `3.6.9' is not installed (set by PYENV_VERSION environment variable)
Step finished unsuccessfully.
Step 'Run tests' finished unsuccessfully.
```

Probably the base image being openjdk we need to first install python
tooling before using it. I don't have a lot of experience with python so I'm not sure. Maybe it's just missing some env variable, so I'm trying out.
