### PR TITLE
Grant write permissions to files that need to be changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ENV SRC_PATH="/bubuku"
 ADD ./bubuku "${SRC_PATH}/bubuku"
 ADD ./requirements.txt "${SRC_PATH}/"
 ADD ./setup.py "${SRC_PATH}/"
-RUN cd "${SRC_PATH}" && \
+RUN mkdir -p $KAFKA_LOGS_DIR/ && \
+    cd "${SRC_PATH}" && \
     pip3 install --no-cache-dir -r "requirements.txt" && \
     python3 setup.py develop && \
     chmod -R 777 $KAFKA_LOGS_DIR && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ ENV SRC_PATH="/bubuku"
 ADD ./bubuku "${SRC_PATH}/bubuku"
 ADD ./requirements.txt "${SRC_PATH}/"
 ADD ./setup.py "${SRC_PATH}/"
-RUN cd "${SRC_PATH}" && pip3 install --no-cache-dir -r "requirements.txt" && python3 setup.py develop
+RUN cd "${SRC_PATH}" && \
+    pip3 install --no-cache-dir -r "requirements.txt" && \
+    python3 setup.py develop && \
+    chmod -R 777 $KAFKA_LOGS_DIR && \
+    chmod 777 ${KAFKA_SETTINGS}
 
 EXPOSE 9092 8080 8778
 


### PR DESCRIPTION
When bubuku process is booting it overwrites the broker id in server
properties (or at least open this file with write permission).

The lack of such permission resulted in:

```
ERROR:bubuku.features.restart_on_zk:Failed to start kafka process against 10.154.206.111:2181,10.154.192.139:2181,10.154.215.44:2181/staging-fra-2
 Traceback (most recent call last):
   File "/bubuku/bubuku/features/restart_on_zk_change.py", line 38, in run
     self.broker.start_kafka_process(zk_conn_str)
   File "/bubuku/bubuku/broker.py", line 133, in start_kafka_process
     self.kafka_properties.dump()
   File "/bubuku/bubuku/config.py", line 47, in dump
     with open(self.settings_file, mode='w') as f:
 PermissionError: [Errno 13] Permission denied:
 '/opt/kafka/config/server.properties'
 ```

I'm not sure why it works locally with docker-compose. Possibly
because it runs in a different mode with different toggles and features.
