### PR TITLE
Upgrade Kafka to version 2.6.0 with Scala 2.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.opensource.zalan.do/stups/openjdk:1.8.0-232-23
 MAINTAINER Team Aruha, team-aruha@zalando.de
 
-ENV KAFKA_VERSION="2.4.1" SCALA_VERSION="2.12" JOLOKIA_VERSION="1.6.2"
+ENV KAFKA_VERSION="2.6.0" SCALA_VERSION="2.13" JOLOKIA_VERSION="1.6.2"
 ENV KAFKA_LOGS_DIR="/data/logs"
 ENV KAFKA_DIR="/opt/kafka"
 ENV HEALTH_PORT=8080


### PR DESCRIPTION
This upgrade addresses major issues that impact Nakadi SQL (on the
client side) as well as performance issues on the broker side (large
number of partitions per broker are now less taxing on cpu).

You can read more about the changes in this blog post https://blogs.apache.org/kafka/entry/what-s-new-in-apache3

