### PR TITLE
Kafka ugprade to 2.6.0 phase 2 of 3

### DIFF
--- a/docker/server.properties
+++ b/docker/server.properties
@@ -53,7 +53,7 @@ fetch.purgatory.purge.interval.requests=100
 producer.purgatory.purge.interval.requests=100
 
 #migration
-inter.broker.protocol.version=2.4
+inter.broker.protocol.version=2.6
 log.message.format.version=2.4
 
 # never expire consumer offsets


### PR DESCRIPTION
This changes the inter broker protocol to the latest version. Once
this is rolled out, there is no rolling back to the previous Kafka
version. At least not that the documentation recommends.
