### PR TITLE
Upgrade Kafka 2.6.0 part 3: log.message.format

### DIFF
--- a/docker/server.properties
+++ b/docker/server.properties
@@ -54,7 +54,7 @@ producer.purgatory.purge.interval.requests=100
 
 #migration
 inter.broker.protocol.version=2.6
-log.message.format.version=2.4
+log.message.format.version=2.6
 
 # never expire consumer offsets
 offsets.retention.minutes=52560000


### PR DESCRIPTION
Since the previous release where we modified the
inter.broker.protocol.version to version 2.6.0 we noticed an increase
in CPU usage. We suspect it could be due to conversions so we are
going to try to deploy Kafka with message format 2.6 to see if we less
conversions the CPU usage goes down.

Since most messages come from Nakadi with version 2.6 client, this
should reduce amount of conversions done.

