### PR TITLE
Enable rolling restart resuming

### DIFF
--- a/bubuku/features/rolling_restart.py
+++ b/bubuku/features/rolling_restart.py
@@ -309,7 +309,7 @@ class RegisterRollingRestart(State):
                           'scalyr_region': self.state_context.cluster_config.get_scalyr_region(),
                           'kms_key_id': self.state_context.cluster_config.get_kms_key_id(),
                           'cool_down': self.state_context.cool_down}
-                next_broker_id = sorted(list(self.state_context.restart_assignment.keys()))[0]
+                next_broker_id = self.state_context.broker_id_to_restart
                 self.state_context.zk.register_action(action, broker_id=next_broker_id)
                 return True
             return False

--- a/docker/server.properties
+++ b/docker/server.properties
@@ -54,7 +54,7 @@ producer.purgatory.purge.interval.requests=100
 
 #migration
 inter.broker.protocol.version=2.6
-log.message.format.version=2.6
+log.message.format.version=2.4
 
 # never expire consumer offsets
 offsets.retention.minutes=52560000

--- a/docker/server.properties
+++ b/docker/server.properties
@@ -54,7 +54,7 @@ producer.purgatory.purge.interval.requests=100
 
 #migration
 inter.broker.protocol.version=2.6
-log.message.format.version=2.4
+log.message.format.version=2.6
 
 # never expire consumer offsets
 offsets.retention.minutes=52560000


### PR DESCRIPTION
Start restart from a specific broker
When performing a rolling restart, if broker A is restarting broker B
and for some reason an exception is thrown, this exception might cause
the rolling restart process to be interrupted.

This just happened on production leaving our cluster with 1 less
instance.

In order to be able to resume the rolling restart exactly where it
stopped, without having to restart everything from the beginning, I
changed this 1 line of code.

The plan is to upgrade one broker and trigger the rolling restart from
there. Then, this will cause the rolling restart to go from there
on. It will eventually restart brokers that were already restarted in a
previous run of the rolling restart but at least we are now able to
run rolling restart from a specific point and be sure it starts from
there on.

We can manually stop the rolling restart if all instances were already
restarted.

Without this change, it is impossible to restart all brokers
automatically since every time you have to trigger the restart it will
start from the broker in position ZERO again.