### PR TITLE
Make special build for production deployment

### DIFF
--- a/docker/server.properties
+++ b/docker/server.properties
@@ -54,7 +54,7 @@ producer.purgatory.purge.interval.requests=100
 
 #migration
 inter.broker.protocol.version=2.6
-log.message.format.version=2.6
+log.message.format.version=2.4
 
 # never expire consumer offsets
 offsets.retention.minutes=52560000


### PR DESCRIPTION
This is a continuation of
https://github.com/zalando-nakadi/bubuku/pull/158 which was built for
staging validation. Now I'm setting log.message.format to 2.4 to
continue production deployment.

