### PR TITLE
Wait for leadership finish and exclude new topics

### DIFF
--- a/bubuku/broker.py
+++ b/bubuku/broker.py
@@ -124,7 +124,8 @@ class BrokerManager(object):
         :raise LeaderElectionInProgress: raised when broker can not be started because leader election is in progress
         """
         if not self.process.is_running():
-            self.wait_while_leadership_transferred(active_broker_ids=self.exhibitor.get_broker_ids())
+            if not self._is_leadership_transferred(active_broker_ids=self.exhibitor.get_broker_ids()):
+                raise LeaderElectionInProgress()
 
             _LOG.info('Using ZK address: {}'.format(zookeeper_address))
             self.kafka_properties.set_property('zookeeper.connect', zookeeper_address)
@@ -147,17 +148,11 @@ class BrokerManager(object):
                 _LOG.error(
                     'Failed to wait for broker to start up, probably will kill, next timeout is'.format(self.timeout))
 
-    def wait_while_leadership_transferred(self, active_broker_ids=None, dead_broker_ids=None):
-        while not self._is_leadership_transferred(active_broker_ids, dead_broker_ids):
-            _LOG.info(
-                "Waiting for leadership to transfer for topics before starting kafka process")
-            sleep(5)
-
     def _is_leadership_transferred(self, active_broker_ids=None, dead_broker_ids=None):
         _LOG.info('Checking if leadership is transferred: active_broker_ids={}, dead_broker_ids={}'.format(
             active_broker_ids, dead_broker_ids))
         if self._is_clean_election():
-            topics = self.exhibitor.load_topics(minimum_age_seconds=120)
+            topics = self.exhibitor.load_active_topics()
             for topic, partition, state in self.exhibitor.load_partition_states(topics=topics):
                 leader = str(state['leader'])
                 if active_broker_ids and leader not in active_broker_ids:

--- a/bubuku/zookeeper/__init__.py
+++ b/bubuku/zookeeper/__init__.py
@@ -4,6 +4,7 @@ import threading
 import time
 import uuid
 from typing import Dict, List, Iterable, Tuple
+from datetime import datetime, timezone, timedelta
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NodeExistsError, NoNodeError, ConnectionLossException
@@ -219,6 +220,32 @@ class BukuExhibitor(object):
         return {
         int(broker): json.loads(self.exhibitor.get('/brokers/ids/{}'.format(broker))[0].decode('utf-8')).get('rack') for
         broker in self.get_broker_ids()}
+
+    def load_topics(self, minimum_age_seconds=None) -> Iterable[str]:
+        """
+        Lists the topics in Kafka. Newer topics can be excluded with specifying a min age
+        :return: a list of topics
+        """
+        topics = self.exhibitor.get_children('/brokers/topics')
+        if not minimum_age_seconds:
+            return iter(topics)
+        
+        if self.async_:
+            results = [(topic, self.exhibitor.get_async('/brokers/topics/{}'.format(topic))) for topic in topics]
+            for topic, cb in results:
+                try:
+                    _, metadata = cb.get(block=True)
+                except ConnectionLossException:
+                    metadata = self.exhibitor.get('/brokers/topics/{}'.format(topic))[1]
+                if datetime.fromtimestamp(metadata.created, timezone.utc) < \
+                        datetime.now(timezone.utc) - timedelta(seconds=minimum_age_seconds):
+                    yield topic
+        else:
+            for topic in topics:
+                metadata = self.exhibitor.get('/brokers/topics/{}'.format(topic))[1]
+                if datetime.fromtimestamp(metadata.created, timezone.utc) < \
+                        datetime.now(timezone.utc) - timedelta(seconds=minimum_age_seconds):
+                    yield topic
 
     def load_partition_assignment(self, topics=None) -> Iterable[Tuple[str, int, List[int]]]:
         """

--- a/bubuku/zookeeper/__init__.py
+++ b/bubuku/zookeeper/__init__.py
@@ -221,12 +221,13 @@ class BukuExhibitor(object):
         int(broker): json.loads(self.exhibitor.get('/brokers/ids/{}'.format(broker))[0].decode('utf-8')).get('rack') for
         broker in self.get_broker_ids()}
 
-    def load_topics(self, minimum_age_seconds=None) -> Iterable[str]:
+    def load_active_topics(self, minimum_age_seconds=None) -> Iterable[str]:
         """
-        Lists the topics in Kafka. Newer topics can be excluded with specifying a min age
+        Lists the topics that are not being deleted from Kafka. Newer topics can be excluded with specifying a min age
         :return: a list of topics
         """
-        topics = self.exhibitor.get_children('/brokers/topics')
+        topics = [topic for topic in self.exhibitor.get_children('/brokers/topics')
+                  if topic not in self.exhibitor.get_children('/admin/delete_topics')]
         if not minimum_age_seconds:
             return iter(topics)
         

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -47,7 +47,7 @@ class TestBroker(unittest.TestCase):
         exhibitor = MagicMock()
         states = [2, 2]
 
-        def _load_states():
+        def _load_states(topics=None):
             for idx in range(0, len(states)):
                 states[idx] -= 1
             return [
@@ -81,7 +81,7 @@ class TestBroker(unittest.TestCase):
         # suppose that leader is not present
         try:
             broker.start_kafka_process(zk_fake_host)
-            assert False, 'broker 1 must be in leaders, it must be impossible to start it'
+            assert False, 'broker 2 must be in leaders, it must be impossible to start 1'
         except LeaderElectionInProgress:
             pass
 

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -26,6 +26,23 @@ def test_get_broker_ids():
     assert ['1', '2', '3'] == buku.get_broker_ids()  # ensure that return list is sorted
 
 
+def test_load_active_topics():
+    exhibitor_mock = MagicMock()
+
+    def _get_children(path):
+        if path == '/brokers/topics':
+            return ['3', '1', '2']
+        elif path == '/admin/delete_topics':
+            return ['3', '1']
+        else:
+            raise NotImplementedError()
+
+    exhibitor_mock.get_children = _get_children
+    buku = BukuExhibitor(exhibitor_mock)
+
+    assert ['2'] == buku.load_active_topics()
+
+
 def test_is_broker_registered():
     def _get(path):
         if path == '/brokers/ids/123':


### PR DESCRIPTION
[ARUHA-3130: Bubuku may hang up on start](https://jira.zalando.net/browse/ARUHA-3130)

Bubuku may hang up on start for new topics being under creation. For example:
```
  WARNING:bubuku.broker:Leadership is not transferred for 769c2845-4aee-4b38-8b80-087cc08817e4 2 ({"controller_epoch": 61, "leader": -1, "version": 1, "leader_epoch": 110, "isr": [67123066]}, brokers: ['67123027', '67123028', '67123033', '67123034', '67123035', '67123036', '67123037', '67123038', '67123039', '67123040', '67123041', '67123044', '67123046', '67123047', '67123048', '67123049', '67123050', '67123051', '67123052', '67123053', '67123055', '67123056', '67123057', '67123058', '67123059', '67123060', '67123061', '67123062', '67123063', '67123064', '67123065', '67123066', '67123427'])
```

In this pull request, I change the code to wait indefinitely for leadership transfer to complete since we start brokers sequentially during a rolling restart and none of the brokers would start if any leadership transfer is in progress.

Since leadership transfer check is done for both starting and stopping of brokers, also added a check to remove topics of certain age from the check. That is implemented by querying zookeeper for `created_at` time.
