### PR TITLE
Use rack-aware replica selector for consumption

### DIFF
--- a/docker/server.properties
+++ b/docker/server.properties
@@ -19,6 +19,7 @@ replica.socket.timeout.ms=30000
 replica.socket.receive.buffer.bytes=65536
 replica.lag.time.max.ms=10000
 replica.lag.max.messages=4000
+replica.selector.class=org.apache.kafka.common.replica.RackAwareReplicaSelector
 
 controller.socket.timeout.ms=30000
 controller.message.queue.size=10


### PR DESCRIPTION
In case if clients are asking to consume from follower, they are still forced to consume from leader. 
In this PR the rack selector is modified to comply with client wishes - consumer from the same rack. 

`broker.rack` value is set by AWS environment provider. In case if clients do want to continue consumption from the leader, they have to avoid setting `client.rack`.