### PR TITLE
Don't prevent start of broker under rolling_restart

### DIFF
--- a/bubuku/features/remote_exec.py
+++ b/bubuku/features/remote_exec.py
@@ -7,7 +7,7 @@ from bubuku.features.migrate import MigrationChange
 from bubuku.features.rebalance.change import OptimizedRebalanceChange
 from bubuku.features.rebalance.change_simple import SimpleRebalanceChange
 from bubuku.features.restart_on_zk_change import RestartBrokerChange
-from bubuku.features.rolling_restart import RollingRestartChange, StartBrokerChange
+from bubuku.features.rolling_restart import RollingRestartChange
 from bubuku.features.swap_partitions import SwapPartitionsChange, load_swap_data
 from bubuku.features.terminate import CompleteStopChange
 from bubuku.zookeeper import BukuExhibitor

--- a/bubuku/features/restart_on_zk_change.py
+++ b/bubuku/features/restart_on_zk_change.py
@@ -22,7 +22,7 @@ class RestartBrokerChange(Change):
         return 'restart'
 
     def can_run(self, current_actions):
-        return all([a not in current_actions for a in ['start', 'restart', 'stop', 'complete_stop', 'rolling_restart']])
+        return all([a not in current_actions for a in ['start', 'restart', 'stop', 'complete_stop']])
 
     def run(self, current_actions):
         if self.stage == _STAGE_STOP:

--- a/bubuku/features/rolling_restart.py
+++ b/bubuku/features/rolling_restart.py
@@ -55,27 +55,6 @@ class RollingRestartChange(Change):
         return self.state_context.run()
 
 
-class StartBrokerChange(Change):
-    def __init__(self, zk: BukuExhibitor, broker: BrokerManager):
-        self.zk = zk
-        self.broker = broker
-
-    def get_name(self):
-        return 'start'
-
-    def can_run(self, current_actions):
-        return all([a not in current_actions for a in ['restart', 'stop', 'complete_stop']])
-
-    def run(self, current_actions):
-        zk_conn_str = self.zk.get_conn_str()
-        try:
-            self.broker.start_kafka_process(zk_conn_str)
-        except Exception as e:
-            _LOG.error('Failed to start kafka process against {}'.format(zk_conn_str), exc_info=e)
-            return True
-        return False
-
-
 class StateContext:
     def __init__(self, zk: BukuExhibitor, aws: AWSResources, ec_node: Ec2Node, ec2_node_launcher: Ec2NodeLauncher,
                  broker_id_to_restart, restart_assignment, cluster_config: ClusterConfig, cool_down: int):


### PR DESCRIPTION
Follow up on #173

Also, remove `StartBrokerChange`: it is not used anywhere else.