### PR TITLE
Make timeout before next run of a change configurable

### DIFF
--- a/bubuku/controller.py
+++ b/bubuku/controller.py
@@ -163,7 +163,7 @@ class Controller(object):
             self.make_step()
             sleep_and_operate(self, self._get_loop_timeout())
 
-    def _get_loop_timeout(self):
+    def _get_loop_timeout(self) -> float:
         if self.changes:
             timeout = min(change.time_till_next_run() for change in self.changes)
         else:

--- a/bubuku/controller.py
+++ b/bubuku/controller.py
@@ -16,8 +16,15 @@ class Change(object):
     def can_run(self, current_actions) -> bool:
         raise NotImplementedError('Not implemented yet')
 
+    #
+    # Returns a flag indicating if the change should continue running (True).
+    # In that case time_till_next_run() is called to determine when to schedule the next run.
+    #
     def run(self, current_actions) -> bool:
         raise NotImplementedError('Not implemented')
+
+    def time_till_next_run(self) -> float:
+        return 0.5
 
     def can_run_at_exit(self) -> bool:
         return False
@@ -154,12 +161,14 @@ class Controller(object):
             self._add_change_to_queue(change_on_init)
         while self.running or self.changes:
             self.make_step()
+            sleep_and_operate(self, self._get_loop_timeout())
 
-            if self.changes:
-                timeout = 0.5
-            else:
-                timeout = min([check.time_till_check() for check in self.checks])
-            sleep_and_operate(self, timeout)
+    def _get_loop_timeout(self):
+        if self.changes:
+            timeout = min(change.time_till_next_run() for change in self.changes)
+        else:
+            timeout = min(check.time_till_check() for check in self.checks)
+        return timeout
 
     def make_step(self):
         # register running changes

--- a/bubuku/features/rolling_restart.py
+++ b/bubuku/features/rolling_restart.py
@@ -54,6 +54,9 @@ class RollingRestartChange(Change):
     def run(self, current_actions) -> bool:
         return self.state_context.run()
 
+    def time_till_next_run(self):
+        return 10
+
 
 class StateContext:
     def __init__(self, zk: BukuExhibitor, aws: AWSResources, ec_node: Ec2Node, ec2_node_launcher: Ec2NodeLauncher,


### PR DESCRIPTION
Apply 10 seconds timeout for `RollingRestartChange` as the default 0.5 seconds
is way too often for the operation of this change.

Internal ticket: 789

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
