### PR TITLE
Use the same ami as the instance that does the restart.

### DIFF
--- a/bubuku/aws/cluster_config.py
+++ b/bubuku/aws/cluster_config.py
@@ -1,96 +1,104 @@
+import logging
+
 import requests
 import yaml
 
 _ARTIFACT_NAME = 'bubuku-appliance'
 
+_LOG = logging.getLogger('bubuku.aws.cluster_config')
 
-class ConfigLoader():
-    def load_config(self) -> dict:
+
+class ConfigLoader(object):
+    def load_user_data(self) -> dict:
+        pass
+
+    def load_region(self) -> str:
+        pass
+
+    def load_ami_id(self) -> str:
         pass
 
 
 class AwsInstanceUserDataLoader(ConfigLoader):
-    def load_config(self):
+    def load_user_data(self):
         return yaml.load(requests.get('http://169.254.169.254/latest/user-data').text)
 
+    def load_region(self) -> str:
+        return requests.get('http://169.254.169.254/latest/meta-data/placement/region').text
 
-class ClusterConfig():
+    def load_ami_id(self) -> str:
+        return requests.get('http://169.254.169.254/latest/meta-data/ami-id').text
+
+
+class ClusterConfig(object):
 
     def __init__(self, config_loader: ConfigLoader):
-        self._user_data = config_loader.load_config()
+        self._user_data = config_loader.load_user_data()
         self._env_vars = self._user_data.get('environment')
+        self._aws_region = config_loader.load_region()
+        self._ami_id = config_loader.load_ami_id()
+        self._overrides = {}
 
     def get_cluster_name(self):
         return self._env_vars.get('CLUSTER_NAME')
 
-    def get_health_port(self):
-        return self._env_vars.get('HEALTH_PORT')
-
     def get_aws_region(self):
-        return 'eu-central-1'
+        return self._aws_region
 
     def get_instance_type(self):
         return self._user_data.get('instance_type')
 
-    def set_scalyr_account_key(self, scalyr_account_key):
-        if scalyr_account_key:
-            self._user_data['scalyr_account_key'] = scalyr_account_key
-
-    def get_scalyr_account_key(self):
-        return self._user_data['scalyr_account_key']
-
-    def set_scalyr_region(self, scalyr_region):
-        if scalyr_region:
-            self._user_data['scalyr_region'] = scalyr_region
-
-    def get_scalyr_region(self):
-        return self._user_data['scalyr_region']
-
-    def set_application_version(self, image):
-        if image:
-            self._user_data['application_version'] = image
-            self._user_data['source'] = 'registry.opensource.zalan.do/aruha/{}:{}'.format(_ARTIFACT_NAME, image)
-
-    def get_application_version(self):
-        return self._user_data.get('application_version')
-
-    def set_instance_type(self, instance_type):
-        if instance_type:
-            self._user_data['instance_type'] = instance_type
-
-    def set_kms_key_id(self, kms_key_id):
-        if kms_key_id:
-            self._user_data['kms_key_id'] = kms_key_id
-
-    def get_kms_key_id(self):
-        return self._user_data.get("kms_key_id")
-
-    def get_availability_zone(self):
-        return self._user_data.get('availability_zone')
-
-    def set_availability_zone(self, availability_zone):
-        if availability_zone:
-            self._user_data['availability_zone'] = availability_zone
-
-    def get_volume_size(self):
-        return self._user_data.get('volume_size')
-
-    def get_volume_type(self):
-        return self._user_data.get('volume_type')
+    def get_ami_id(self):
+        return self._ami_id
 
     def get_vpc_id(self):
         return self._user_data.get('vpc_id')
 
-    def set_vpc_id(self, vpc_id):
-        if vpc_id:
-            self._user_data['vpc_id'] = vpc_id
-
     def get_tags(self):
         return self._user_data.get('tags', [])
 
-    def set_tags(self, tags):
-        if tags:
-            self._user_data['tags'] = tags
-
     def get_user_data(self):
         return dict(self._user_data)
+
+    def get_overrides(self):
+        return self._overrides
+
+    def set_overrides(self, **overrides):
+        self._overrides = overrides
+
+        if overrides.get('application_version'):
+            self._user_data['application_version'] = overrides['application_version']
+            self._user_data['source'] = '{}:{}'.format(
+                self._user_data['source'].split(':', 1)[0], overrides['application_version'])
+        if overrides.get('instance_type'):
+            self._user_data['instance_type'] = overrides['instance_type']
+        if overrides.get('scalyr_account_key'):
+            self._user_data['scalyr_account_key'] = overrides['scalyr_account_key']
+        if overrides.get('scalyr_region'):
+            self._user_data['scalyr_region'] = overrides['scalyr_region']
+        if overrides.get('kms_key_id'):
+            self._user_data['kms_key_id'] = overrides['kms_key_id']
+
+        for k, v in overrides.items():
+            if k not in ('application_version', 'instance_type', 'scalyr_account_key', 'scalyr_region', 'kms_key_id'):
+                _LOG.warning("Unsupported argument %s with value %s", k, v)
+
+    @staticmethod
+    def create_overrides_dict(
+            application_version: str = None,
+            instance_type: str = None,
+            scalyr_account_key: str = None,
+            scalyr_region: str = None,
+            kms_key_id: str = None):
+
+        # Pack arguments by the name passed to the method, in case if value for the argument is set
+        def _filter_out_empty(**kwargs) -> dict:
+            return {k: v for k, v in kwargs.items() if v}
+
+        return _filter_out_empty(
+            application_version=application_version,
+            instance_type=instance_type,
+            scalyr_account_key=scalyr_account_key,
+            scalyr_region=scalyr_region,
+            kms_key_id=kms_key_id,
+        )

--- a/bubuku/aws/cluster_config.py
+++ b/bubuku/aws/cluster_config.py
@@ -78,6 +78,8 @@ class ClusterConfig(object):
             self._user_data['scalyr_region'] = overrides['scalyr_region']
         if overrides.get('kms_key_id'):
             self._user_data['kms_key_id'] = overrides['kms_key_id']
+        if overrides.get('ami_id'):
+            self._ami_id = overrides['ami_id']
 
         for k, v in overrides.items():
             if k not in ('application_version', 'instance_type', 'scalyr_account_key', 'scalyr_region', 'kms_key_id'):
@@ -89,7 +91,8 @@ class ClusterConfig(object):
             instance_type: str = None,
             scalyr_account_key: str = None,
             scalyr_region: str = None,
-            kms_key_id: str = None):
+            kms_key_id: str = None,
+            ami_id: str = None):
 
         # Pack arguments by the name passed to the method, in case if value for the argument is set
         def _filter_out_empty(**kwargs) -> dict:
@@ -101,4 +104,5 @@ class ClusterConfig(object):
             scalyr_account_key=scalyr_account_key,
             scalyr_region=scalyr_region,
             kms_key_id=kms_key_id,
+            ami_id=ami_id
         )

--- a/bubuku/cli.py
+++ b/bubuku/cli.py
@@ -149,13 +149,14 @@ def restart_broker(broker: str):
 @click.option('--scalyr-key', type=click.STRING, help='Scalyr account key')
 @click.option('--scalyr-region', type=click.STRING, help='Scalyr region to use')
 @click.option('--kms-key-id', type=click.STRING, help='Kms key id to decrypt data with')
+@click.option('--ami-id', type=click.STRING, help='Ami id to use')
 @click.option('--cool-down', type=click.INT, default=600, show_default=True,
               help='Number of seconds to wait before passing the restart task to another broker, after cluster is '
                    'stable. Default value of 10 minutes is recommended for production in order to give consumers '
                    'enough time to stabilize in between restarts. This is particularly important for KStream '
                    'applications')
 def rolling_restart_broker(image_tag: str, instance_type: str, scalyr_key: str, scalyr_region: str, kms_key_id: str,
-                           cool_down: int):
+                           ami_id: str, cool_down: int):
     if not is_cluster_healthy():
         print('Cluster is not healthy, try again later :)')
         return
@@ -164,7 +165,7 @@ def rolling_restart_broker(image_tag: str, instance_type: str, scalyr_key: str, 
     with load_exhibitor_proxy(env_provider.get_address_provider(), config.zk_prefix) as zookeeper:
         broker_id = get_opt_broker_id(None, config, zookeeper, env_provider)
         RemoteCommandExecutorCheck.register_rolling_restart(zookeeper, broker_id, image_tag, instance_type, scalyr_key,
-                                                            scalyr_region, kms_key_id, cool_down)
+                                                            scalyr_region, kms_key_id, ami_id, cool_down)
 
 
 @cli.command('rebalance', help='Run rebalance process on one of brokers. If rack-awareness is enabled, replicas will '

--- a/bubuku/features/remote_exec.py
+++ b/bubuku/features/remote_exec.py
@@ -140,7 +140,7 @@ class RemoteCommandExecutorCheck(Check):
 
     @staticmethod
     def register_rolling_restart(zk: BukuExhibitor, broker_id: str, image: str, instance_type: str, scalyr_key: str,
-                                 scalyr_region: str, kms_key_id: str, cool_down: int):
+                                 scalyr_region: str, kms_key_id: str, ami_id: str, cool_down: int):
         if zk.is_rolling_restart_in_progress():
             _LOG.warning('Rolling restart in progress, skipping')
             return
@@ -165,6 +165,7 @@ class RemoteCommandExecutorCheck(Check):
                 scalyr_region=scalyr_region,
                 instance_type=instance_type,
                 kms_key_id=kms_key_id,
+                ami_id=ami_id,
             ),
             'cool_down': cool_down
         }

--- a/bubuku/features/rolling_restart.py
+++ b/bubuku/features/rolling_restart.py
@@ -6,7 +6,6 @@ from bubuku.aws import AWSResources
 from bubuku.aws.cluster_config import ClusterConfig
 from bubuku.aws.ec2_node_launcher import Ec2NodeLauncher
 from bubuku.aws.node import Ec2Node
-from bubuku.broker import BrokerManager
 from bubuku.controller import Change
 from bubuku.zookeeper import BukuExhibitor
 

--- a/bubuku/features/rolling_restart.py
+++ b/bubuku/features/rolling_restart.py
@@ -13,14 +13,11 @@ _LOG = logging.getLogger('bubuku.features.rolling_restart')
 
 
 class RollingRestartChange(Change):
-    def __init__(self, zk: BukuExhibitor, cluster_config: ClusterConfig,
+    def __init__(self,
+                 zk: BukuExhibitor,
+                 cluster_config: ClusterConfig,
                  restart_assignment,
                  broker_id: str,
-                 image: str,
-                 instance_type: str,
-                 scalyr_key: str,
-                 scalyr_region: str,
-                 kms_key_id: str,
                  cool_down: int):
         self.zk = zk
         self.restart_assignment = restart_assignment
@@ -29,16 +26,11 @@ class RollingRestartChange(Change):
         self.broker_ip_to_restart = self.zk.get_broker_address(self.broker_id_to_restart)
 
         self.cluster_config = cluster_config
-        self.cluster_config.set_application_version(image)
-        self.cluster_config.set_instance_type(instance_type)
-        self.cluster_config.set_scalyr_account_key(scalyr_key)
-        self.cluster_config.set_scalyr_region(scalyr_region)
-        self.cluster_config.set_kms_key_id(kms_key_id)
 
         self.aws = AWSResources(region=self.cluster_config.get_aws_region())
         self.ec_node = Ec2Node(self.aws, self.cluster_config, self.broker_ip_to_restart)
-        self.ec2_node_launcher = Ec2NodeLauncher(self.aws, self.cluster_config)
-        self.cluster_config.set_availability_zone(self.ec_node.get_node_availability_zone())
+        self.ec2_node_launcher = Ec2NodeLauncher(
+            self.aws, self.cluster_config, self.ec_node.get_node_availability_zone())
 
         self.state_context = StateContext(self.zk, self.aws, self.ec_node, self.ec2_node_launcher,
                                           self.broker_id_to_restart, self.restart_assignment,
@@ -116,7 +108,6 @@ class State:
         """
         Runs func() with timeout
         :param func function to execute
-        :param timeout_s timeout before executing state next time
         """
         if time() >= self.time_to_check_s:
             self.time_to_check_s = time() + 10
@@ -271,11 +262,7 @@ class RegisterRollingRestart(State):
             if time() - self.cluster_is_healthy_from >= self.state_context.cool_down:
                 action = {'name': 'rolling_restart',
                           'restart_assignment': self.state_context.restart_assignment,
-                          'image': self.state_context.cluster_config.get_application_version(),
-                          'instance_type': self.state_context.cluster_config.get_instance_type(),
-                          'scalyr_key': self.state_context.cluster_config.get_scalyr_account_key(),
-                          'scalyr_region': self.state_context.cluster_config.get_scalyr_region(),
-                          'kms_key_id': self.state_context.cluster_config.get_kms_key_id(),
+                          'overrides': self.state_context.cluster_config.get_overrides(),
                           'cool_down': self.state_context.cool_down}
                 next_broker_id = self.state_context.broker_id_to_restart
                 self.state_context.zk.register_action(action, broker_id=next_broker_id)


### PR DESCRIPTION
Right now during rolling-restart bubuku is trying to find some ami according to some filter that is hard coded in the bubuku code. 

This PR is making it different - the ami that is used on the instance will be used on all the other instances. 
The upgrade procedure is the following: 
1. upgrade ami on one of the instances.
2. run the rolling restart from that instance.

