### PR TITLE
Build 2 different images for different platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:jdk-slim
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/openjdk-11-jdk-slim:latest
+FROM ${BASE_IMAGE}
 MAINTAINER Team Aruha, team-aruha@zalando.de
 
 ENV KAFKA_VERSION="2.7.1" SCALA_VERSION="2.13" JOLOKIA_VERSION="1.6.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/openjdk-11-jdk-slim:latest
+FROM openjdk:jdk-slim
 MAINTAINER Team Aruha, team-aruha@zalando.de
 
 ENV KAFKA_VERSION="2.7.1" SCALA_VERSION="2.13" JOLOKIA_VERSION="1.6.2"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -22,7 +22,11 @@ pipeline:
             echo "Building bubuku for platform $platform"
             IMAGE=registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-${CDP_BUILD_VERSION}-${platform}
             
-            docker buildx build --platform linux/${platform} -t $IMAGE .
+            if [[ $platform == "arm64" ]]; then
+              docker buildx build --build-arg BASE_IMAGE=registry.opensource.zalan.do/library/experimental-openjdk-11-jdk-slim-arm:latest --platform linux/${platform} -t $IMAGE .
+            else
+              docker buildx build --platform linux/${platform} -t $IMAGE .
+            fi
             if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
               docker push $IMAGE
             fi

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -13,7 +13,7 @@ pipeline:
           pip3 install -r requirements.txt 
           python3 setup.py test
 
-      - desc: Build arm docker image
+      - desc: Build docker images for different architectures
         cmd: |
 
           docker run --privileged --rm tonistiigi/binfmt --install all

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -23,7 +23,7 @@ pipeline:
             IMAGE=registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-${CDP_BUILD_VERSION}-${platform}
             
             if [[ $platform == "arm64" ]]; then
-              docker buildx build --build-arg BASE_IMAGE=registry.opensource.zalan.do/library/experimental-openjdk-11-jdk-slim-arm:latest --platform linux/${platform} -t $IMAGE .
+              docker buildx build --build-arg BASE_IMAGE=registry.opensource.zalan.do/library/experimental-openjdk-11-jdk-slim-arm64:latest --platform linux/${platform} -t $IMAGE .
             else
               docker buildx build --platform linux/${platform} -t $IMAGE .
             fi

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,32 +2,36 @@ version: "2017-09-20"
 pipeline:
   - id: build
     type: script
-    overlay: guild-python/legacy
+    vm_config: 
+      type: linux
+      priority: 3
     env:
         PYENV_VERSION: 3.8.10
     commands:
-      - desc: Install Docker
-        cmd: |
-          curl -fLOsS https://delivery.cloud.zalando.com/utils/ensure-docker && sh ensure-docker && rm ensure-docker
-
       - desc: Run tests
         cmd: |
           pip3 install -r requirements.txt 
           python3 setup.py test
 
-      - desc: Build and push Docker image
+      - desc: Build arm docker image
         cmd: |
 
-          IMAGE=registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-${CDP_BUILD_VERSION}
+          docker run --privileged --rm tonistiigi/binfmt --install all
 
-          docker build -t $IMAGE .
+          for platform in "arm64" "amd64"; do 
+            echo "Building bubuku for platform $platform"
+            IMAGE=registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-${CDP_BUILD_VERSION}-${platform}
+            
+            docker buildx build --platform linux/${platform} -t $IMAGE .
+            if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
+              docker push $IMAGE
+            fi
+            
+            TEST_IMAGE="registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-test-${CDP_BUILD_VERSION}-${platform}"
+            docker tag "$IMAGE" "$TEST_IMAGE"
+            docker push "$TEST_IMAGE"
+          done
 
-          if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
-            docker push $IMAGE
-          fi
-          TEST_IMAGE="registry-write.opensource.zalan.do/aruha/bubuku-appliance:oss-test-${CDP_BUILD_VERSION}"
-          docker tag "$IMAGE" "$TEST_IMAGE"
-          docker push "$TEST_IMAGE"
 notifications:
   - channel: google_chat
     rooms:


### PR DESCRIPTION
Right now the base image for bubuku is not supporting multiarch, hence it makes it impossible to run on arm64 architectures.

This PR allows to make 2 different images based on 2 different base images, that are allowing to run bubuku+kafka on 2 different platrorms (amd64 and arm64)