### PR TITLE
Fix yaml loader

### DIFF
--- a/bubuku/aws/cluster_config.py
+++ b/bubuku/aws/cluster_config.py
@@ -21,7 +21,7 @@ class ConfigLoader(object):
 
 class AwsInstanceUserDataLoader(ConfigLoader):
     def load_user_data(self):
-        return yaml.load(requests.get('http://169.254.169.254/latest/user-data').text)
+        return yaml.load(requests.get('http://169.254.169.254/latest/user-data').text, Loader=yaml.FullLoader)
 
     def load_region(self) -> str:
         return requests.get('http://169.254.169.254/latest/meta-data/placement/region').text


### PR DESCRIPTION
With the new version of pyaml (6), Loader arg became mandatory. 