### PR TITLE
Reset the failed check timestamp

### DIFF
--- a/bubuku/features/restart_if_dead.py
+++ b/bubuku/features/restart_if_dead.py
@@ -44,6 +44,8 @@ class CheckBrokerStopped(Check):
             time_to_restart_at = self.last_zk_session_failed_check + timedelta(milliseconds=self.broker.get_zookeeper_session_timeout() * 2)
             if current_time > time_to_restart_at:
                 return True
+        else:
+            self.last_zk_session_failed_check = None
         return False
 
     def on_change_executed(self):


### PR DESCRIPTION
If bubuku realizes that the broker is actually recovered, it should reset the last failed check because a restart change might not be necessary on events when it recovers.

ARUHA-175
