### PR TITLE
Use listeners kafka property instead of advertised.host.name and port properties

### DIFF
--- a/bubuku/controller.py
+++ b/bubuku/controller.py
@@ -163,7 +163,7 @@ class Controller(object):
                     self.zk.unregister_change(name)
 
     def loop(self, change_on_init=None):
-        self.provider_id = self.env_provider.get_id()
+        self.provider_id = self.env_provider.get_ip()
         if change_on_init:
             self._add_change_to_queue(change_on_init)
         while self.running or self.changes:

--- a/bubuku/daemon.py
+++ b/bubuku/daemon.py
@@ -45,7 +45,7 @@ def apply_features(api_port, features: dict, controller: Controller, buku_proxy:
                 protocol, _ignore, port = listener.split(":")
                 new_listeners.append("{protocol}://{host}:{port}".format(
                     protocol=protocol,
-                    host=env_provider.get_id(),
+                    host=env_provider.get_ip(),
                     port=port
                 ))
             kafka_properties.set_property('listeners', ",".join(new_listeners))

--- a/bubuku/env_provider.py
+++ b/bubuku/env_provider.py
@@ -16,7 +16,7 @@ _LOG = logging.getLogger('bubuku.amazon')
 
 
 class EnvProvider(object):
-    def get_id(self) -> str:
+    def get_ip(self) -> str:
         raise NotImplementedError('Not implemented')
 
     def get_address_provider(self):
@@ -53,7 +53,7 @@ class AmazonEnvProvider(EnvProvider):
             _LOG.info("Amazon specific information loaded from AWS: {}".format(json.dumps(self._document, indent=2)))
         return self._document
 
-    def get_id(self) -> str:
+    def get_ip(self) -> str:
         if not self.ip_address:
             self.ip_address = self._get_document()['privateIp']
         return self.ip_address
@@ -105,10 +105,9 @@ class StaticAddressesProvider(AddressListProvider):
 
 
 class LocalEnvProvider(EnvProvider):
-    unique_id = str(uuid.uuid4())
 
-    def get_id(self) -> str:
-        return self.unique_id
+    def get_ip(self) -> str:
+        return '127.0.0.1'
 
     def get_address_provider(self):
         return _LocalAddressProvider()

--- a/docker/server.properties
+++ b/docker/server.properties
@@ -1,5 +1,5 @@
 log.dirs=/data/kafka-logs
-port=9092
+listeners=PLAINTEXT://:9092
 auto.create.topics.enable=false
 delete.topic.enable=true
 auto.leader.rebalance.enable=true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ requests>=2.24.0
 click>=7.1.2
 pyyaml>=5.3.1
 netaddr>=0.8.0
-timeout-decorator>=0.5.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ from bubuku.config import KafkaProperties, load_config, _load_timeout_dict
 
 __PROPS = """
 log.dirs=/data/kafka-logs
-port=9092
 auto.create.topics.enable=false
 delete.topic.enable=true
 auto.leader.rebalance.enable=true

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -82,7 +82,7 @@ def test_use_ip_address_default():
     props = build_test_properties()
 
     amazon = MagicMock()
-    amazon.get_id = MagicMock(return_value='172.31.146.57')
+    amazon.get_ip = MagicMock(return_value='172.31.146.57')
 
     apply_features(-1, {'use_ip_address': {}}, None, None, None, props, amazon)
 
@@ -94,7 +94,7 @@ def test_use_ip_address_custom():
     props.set_property("listeners", "CUSTOM://:9094")
 
     amazon = MagicMock()
-    amazon.get_id = MagicMock(return_value='172.31.146.57')
+    amazon.get_ip = MagicMock(return_value='172.31.146.57')
 
     apply_features(-1, {'use_ip_address': {}}, None, None, None, props, amazon)
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -78,13 +78,24 @@ def test_graceful_terminate():
     assert b == broker
 
 
-def test_use_ip_address():
+def test_use_ip_address_default():
     props = build_test_properties()
-    assert props.get_property('advertised.host.name') is None
 
     amazon = MagicMock()
     amazon.get_id = MagicMock(return_value='172.31.146.57')
 
     apply_features(-1, {'use_ip_address': {}}, None, None, None, props, amazon)
 
-    assert props.get_property('advertised.host.name') == '172.31.146.57'
+    assert props.get_property('listeners') == 'PLAINTEXT://172.31.146.57:9092'
+
+
+def test_use_ip_address_custom():
+    props = build_test_properties()
+    props.set_property("listeners", "CUSTOM://:9094")
+
+    amazon = MagicMock()
+    amazon.get_id = MagicMock(return_value='172.31.146.57')
+
+    apply_features(-1, {'use_ip_address': {}}, None, None, None, props, amazon)
+
+    assert props.get_property('listeners') == 'CUSTOM://172.31.146.57:9094'

--- a/tests/test_restart_if_dead.py
+++ b/tests/test_restart_if_dead.py
@@ -1,10 +1,9 @@
 import unittest
 from unittest.mock import MagicMock
 from bubuku.features.restart_if_dead import CheckBrokerStopped
-from timeout_decorator import timeout
 
 class TestRestartIfDeadCheck(unittest.TestCase):
-    @timeout(0.5)
+
     def test_broker_retries_before_it_restarts(self):
         brokerManager = MagicMock()
         isRegistered = MagicMock(return_value=False)


### PR DESCRIPTION
## Description
After [kafka 3.0 release](https://kafka.apache.org/documentation/#upgrade_300_notable) there were some properties removed: 
`advertised.host.name, advertised.port, port`. 
The new way of managing these properties is to use `listeners` and `advertized.listeners` configuration. 